### PR TITLE
maru-amd64: remove x86 reference

### DIFF
--- a/overlay-maru-amd64/virtual/chromeos-config-bsp/chromeos-config-bsp-2.ebuild
+++ b/overlay-maru-amd64/virtual/chromeos-config-bsp/chromeos-config-bsp-2.ebuild
@@ -8,7 +8,7 @@ HOMEPAGE="http://src.chromium.org"
 
 LICENSE="BSD-Google"
 SLOT="0"
-KEYWORDS="-* amd64 x86"
+KEYWORDS="-* amd64"
 
 DEPEND="chromeos-base/chromeos-config-bsp-maru-amd64"
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
Signed-off-by: Ayane Satomi <sr229@coder.com>